### PR TITLE
fix: No longer `cp` to directory that does not exist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ BIN ?= term
 PREFIX ?= /usr/local
 
 install:
+	mkdir -p $(PREFIX)/bin
 	cp term.sh $(PREFIX)/bin/$(BIN)
 
 uninstall:


### PR DESCRIPTION
Title